### PR TITLE
Remove starship, re-add autoremove

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -yq install --no-install-recommends \
         tree \
         lsof \
         fish \
-        && sh -c "curl -fsSL https://starship.rs/install.sh | bash -s -- --yes" \
+        && apt-get autoremove -y \
         && apt-get clean -y \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This request is being made directly to the `main` branch due to it fixing build failures upon loading into the Dev Container.

## Changes
- Remove `startship` install, as the install breaks dev container creation. This project used [powerlevel10k](https://github.com/romkatv/powerlevel10k) for prompt configuration.
- Add back in the `autoremove` for installation file cleanup